### PR TITLE
Do nothing on keypress if we are not on projector screen

### DIFF
--- a/openslides_presenter/static/js/openslides_presenter/site.js
+++ b/openslides_presenter/static/js/openslides_presenter/site.js
@@ -96,6 +96,11 @@ angular.module('OpenSlidesApp.openslides_presenter.site', ['OpenSlidesApp.opensl
 				return;
 			}
 
+			// Skipping if we're not on the presenter screen.
+			if (window.location.href.indexOf('/presenter') === -1) {
+				return;
+			}
+
 			var sendMessage = function (text, level) {
 				var message = text + '<br/><i style="font-size: 80%;">Pressed key: "' + keysMap[e.keyCode] + '"</i>';
 				return Messaging.createOrEditMessage(


### PR DESCRIPTION
I've faced an issue during Agora: this plugin does not stop reacting to keyboard clicks if I go to another page. This should fix it.
@lesteenman can you check if it's working before and after this PR? Steps to reproduce:
1) open OpenSlides with this plugin
2) go to presenter page
3) go to any other page
4) press any arrow that causes some action
5) it will result in an action, although it shouldn't.